### PR TITLE
fix: skip footnotes and cross-references in USFX parser 

### DIFF
--- a/lib/src/parsers/usfx_parser.dart
+++ b/lib/src/parsers/usfx_parser.dart
@@ -232,17 +232,18 @@ class UsfxParser extends BaseParser {
           } else {
             final trimmedText = event.value.trim();
             if (trimmedText.isNotEmpty) {
-              // Only add a space if the previous text is not empty and doesn't end with a space
               String newText;
               if (currentVerse.text.isEmpty) {
                 newText = trimmedText;
-              } else if (trimmedText.startsWith(RegExp(r'[.,;:!?]'))) {
+              } else if (trimmedText.startsWith(RegExp(r'[.,;:!?)]'))) {
                 newText = currentVerse.text + trimmedText;
               } else {
                 newText = currentVerse.text + ' ' + trimmedText;
               }
               // Remove any space before punctuation
               newText = newText.replaceAll(RegExp(r'\s+([.,;:!?])'), r'\1');
+              // Remove any space after an opening parenthesis
+              newText = newText.replaceAll(RegExp(r'\(\s+'), '(');
               currentVerse = Verse(
                 num: currentVerse.num,
                 chapterNum: currentVerse.chapterNum,
@@ -335,17 +336,18 @@ class UsfxParser extends BaseParser {
           } else {
             final trimmedText = event.value.trim();
             if (trimmedText.isNotEmpty) {
-              // Only add a space if the previous text is not empty and doesn't end with a space
               String newText;
               if (currentVerse.text.isEmpty) {
                 newText = trimmedText;
-              } else if (trimmedText.startsWith(RegExp(r'[.,;:!?]'))) {
+              } else if (trimmedText.startsWith(RegExp(r'[.,;:!?)]'))) {
                 newText = currentVerse.text + trimmedText;
               } else {
                 newText = currentVerse.text + ' ' + trimmedText;
               }
               // Remove any space before punctuation
               newText = newText.replaceAll(RegExp(r'\s+([.,;:!?])'), r'\1');
+              // Remove any space after an opening parenthesis
+              newText = newText.replaceAll(RegExp(r'\(\s+'), '(');
               currentVerse = Verse(
                 num: currentVerse.num,
                 chapterNum: currentVerse.chapterNum,

--- a/lib/src/parsers/usfx_parser.dart
+++ b/lib/src/parsers/usfx_parser.dart
@@ -232,8 +232,17 @@ class UsfxParser extends BaseParser {
           } else {
             final trimmedText = event.value.trim();
             if (trimmedText.isNotEmpty) {
-              // Append text to current verse
-              final newText = [currentVerse.text, trimmedText].join(' ');
+              // Only add a space if the previous text is not empty and doesn't end with a space
+              String newText;
+              if (currentVerse.text.isEmpty) {
+                newText = trimmedText;
+              } else if (trimmedText.startsWith(RegExp(r'[.,;:!?]'))) {
+                newText = currentVerse.text + trimmedText;
+              } else {
+                newText = currentVerse.text + ' ' + trimmedText;
+              }
+              // Remove any space before punctuation
+              newText = newText.replaceAll(RegExp(r'\s+([.,;:!?])'), r'\1');
               currentVerse = Verse(
                 num: currentVerse.num,
                 chapterNum: currentVerse.chapterNum,
@@ -326,7 +335,17 @@ class UsfxParser extends BaseParser {
           } else {
             final trimmedText = event.value.trim();
             if (trimmedText.isNotEmpty) {
-              final newText = [currentVerse.text, trimmedText].join(' ');
+              // Only add a space if the previous text is not empty and doesn't end with a space
+              String newText;
+              if (currentVerse.text.isEmpty) {
+                newText = trimmedText;
+              } else if (trimmedText.startsWith(RegExp(r'[.,;:!?]'))) {
+                newText = currentVerse.text + trimmedText;
+              } else {
+                newText = currentVerse.text + ' ' + trimmedText;
+              }
+              // Remove any space before punctuation
+              newText = newText.replaceAll(RegExp(r'\s+([.,;:!?])'), r'\1');
               currentVerse = Verse(
                 num: currentVerse.num,
                 chapterNum: currentVerse.chapterNum,


### PR DESCRIPTION
The skip logic needs to be added to   Stream<Verse> parseVerses() async* {

Was not skipping footnotes and cross-references

    // Current parsing state
    Book? currentBook;
    Chapter? currentChapter;
    Verse? currentVerse;
    // True when we are inside a <f> tag. These tags are used for
    // footnotes. We skip them for now.
    bool insideFTag = false;
    // True when we are inside a <x> tag. These tags are used for
    // cross-references. We skip them for now.
    bool insideXTag = false;


![Screenshot_20250707_150007](https://github.com/user-attachments/assets/bc956cd6-4f8b-4ca9-935f-a4bbe350871a)
